### PR TITLE
Enable Slurm accounting via SlurmDBD + MariaDB; add DB playbook and omit incorrect SlurmctldPidFile

### DIFF
--- a/db_playbook.yml
+++ b/db_playbook.yml
@@ -1,0 +1,32 @@
+- hosts: slurmdbdservers
+  become: true
+  vars:
+    mysql_socket: /var/run/mysqld/mysqld.sock   # Debian/Ubuntu default
+  tasks:
+    - name: Install MariaDB server + PyMySQL
+      package:
+        name:
+          - mariadb-server
+          - python3-pymysql
+        state: present
+
+    - name: Ensure MariaDB is running
+      service:
+        name: mariadb
+        state: started
+        enabled: true
+
+    - name: Create slurm accounting database
+      community.mysql.mysql_db:
+        name: slurm_acct_db
+        state: present
+        login_unix_socket: "{{ mysql_socket }}"
+
+    - name: Create slurmdbd user with privileges on slurm_acct_db
+      community.mysql.mysql_user:
+        name: slurmdbd
+        host: 127.0.0.1
+        password: "{{ slurmdbd_config.StoragePass }}"
+        priv: "slurm_acct_db.*:ALL"
+        state: present
+        login_unix_socket: "{{ mysql_socket }}"

--- a/inventory/group_vars/all.yml
+++ b/inventory/group_vars/all.yml
@@ -7,16 +7,25 @@ slurm_nodes:
     NodeHostname: "{{ hostvars['node1'].ansible_hostname }}"
     CPUs: "{{ hostvars['node1'].ansible_facts['processor_vcpus'] | default(1) }}"
     RealMemory: "{{ (hostvars['node1'].ansible_facts['memtotal_mb'] | default(2000)) - 100 }}"
+
 slurm_partitions:
   - name: debug
     Nodes: node1
     Default: YES
     State: UP
+
 slurm_config:
   ClusterName: cluster
   ControlMachine: "{{ hostvars['node1'].ansible_hostname }}"
-  AccountingStorageType: accounting_storage/none
+  # — Enable database-backed accounting through SlurmDBD —
+  AccountingStorageType: accounting_storage/slurmdbd
+  AccountingStorageHost: "{{ hostvars['node1'].ansible_hostname }}"
+  AccountingStoragePort: 6819
+  # Recommended so Slurm actually gathers per-job stats:
+  JobAcctGatherType: jobacct_gather/linux
+  # Usual housekeeping:
   StateSaveLocation: /var/lib/slurm/slurmctld
   SlurmdSpoolDir: /var/lib/slurm/slurmd
   MailProg: /bin/true
+
 slurm_create_dirs: true

--- a/inventory/group_vars/slurmdbdservers.yml
+++ b/inventory/group_vars/slurmdbdservers.yml
@@ -1,0 +1,18 @@
+# group_vars/slurmdbdservers.yml
+# NOTE: store real passwords with ansible-vault.
+slurmdbd_config:  
+  DbdHost: "{{ hostvars['node1'].ansible_hostname }}"  
+  DbdPort: 6819  
+  AuthType: auth/munge  
+  SlurmUser: slurm  
+  LogFile: /var/log/slurm/slurmdbd.log  
+  PidFile: /run/slurmdbd.pid  
+  SlurmctldPidFile: "{{ omit }}"  # This explicitly overrides the incorrect default  
+    
+  # Database backend (MariaDB/MySQL):  
+  StorageType: accounting_storage/mysql  
+  StorageHost: 127.0.0.1  
+  StoragePort: 3306  
+  StorageLoc: slurm_acct_db  
+  StorageUser: slurmdbd  
+  StoragePass: "pswd"

--- a/inventory/hosts.yml
+++ b/inventory/hosts.yml
@@ -1,7 +1,7 @@
 all:
   hosts:
     node1:
-      ansible_host: 142.93.203.233
+      ansible_host: 159.89.142.0
   children:
     slurmservers:
       hosts:
@@ -9,4 +9,6 @@ all:
     slurmexechosts:
       hosts:
         node1:
-    # slurmdbdservers group removed due to it being unused and causing errors
+    slurmdbdservers:
+      hosts:
+        node1:


### PR DESCRIPTION
## Summary/Overview

- Adds database-backed accounting to the cluster using SlurmDBD and MariaDB.
- Introduces a dedicated Ansible playbook to provision MariaDB and the slurmdbd database/user.
- Works around a known role bug by explicitly omitting `SlurmctldPidFile` in slurmdbd config.
- Updates inventory to include the `slurmdbdservers` group and host.

## Usage

1. run `ansible-playbook db_playbook.yml`
2. run `ansible-playbook slurm_playbook.yml`

## What & Why

- Problem: Previously, accounting was disabled (`accounting_storage/none`). Enabling SlurmDBD requires:
  - A running MariaDB/MySQL instance with a `slurm_acct_db` database and `slurmdbd` user.
  - Correct Slurm configuration to point to SlurmDBD for accounting.
  - A fix for a role bug where `SlurmctldPidFile` incorrectly appears in `slurmdbd.conf`.
- Why: Database-backed accounting enables `sacct`/`sreport`, historical job visibility, and production-grade job accounting.

## How

- New playbook to install MariaDB and create DB/user with required privileges:

  Here’s the key addition:

  ```yaml
  # filepath: /Users/andrewma/slurm-ansible-project/db_playbook.yml
  # ...existing code...
  - hosts: slurmdbdservers
    become: true
    vars:
      mysql_socket: /var/run/mysqld/mysqld.sock   # Debian/Ubuntu default
    tasks:
      - name: Install MariaDB server + PyMySQL
        package:
          name:
            - mariadb-server
            - python3-pymysql
          state: present

      - name: Ensure MariaDB is running
        service:
          name: mariadb
          state: started
          enabled: true

      - name: Create slurm accounting database
        community.mysql.mysql_db:
          name: slurm_acct_db
          state: present
          login_unix_socket: "{{ mysql_socket }}"

      - name: Create slurmdbd user with privileges on slurm_acct_db
        community.mysql.mysql_user:
          name: slurmdbd
          host: 127.0.0.1
          password: "{{ slurmdbd_config.StoragePass }}"
          priv: "slurm_acct_db.*:ALL"
          state: present
          login_unix_socket: "{{ mysql_socket }}"
  # ...existing code...
  ```

- Enabled Slurm accounting via SlurmDBD and job accounting gatherer:

  ```yaml
  # filepath: /Users/andrewma/slurm-ansible-project/inventory/group_vars/all.yml
  # ...existing code...
  slurm_config:
    ClusterName: cluster
    ControlMachine: "{{ hostvars['node1'].ansible_hostname }}"
    # — Enable database-backed accounting through SlurmDBD —
    AccountingStorageType: accounting_storage/slurmdbd
    AccountingStorageHost: "{{ hostvars['node1'].ansible_hostname }}"
    AccountingStoragePort: 6819
    # Recommended so Slurm actually gathers per-job stats:
    JobAcctGatherType: jobacct_gather/linux
    # Usual housekeeping:
    StateSaveLocation: /var/lib/slurm/slurmctld
    SlurmdSpoolDir: /var/lib/slurm/slurmd
    MailProg: /bin/true
  # ...existing code...
  ```

- Worked around the role bug by omitting the incorrect key in slurmdbd config:

  Link to related issue:

  ```yaml
  # filepath: /Users/andrewma/slurm-ansible-project/inventory/group_vars/slurmdbdservers.yml
  # ...existing code...
    PidFile: /run/slurmdbd.pid
    SlurmctldPidFile: "{{ omit }}"  # This explicitly overrides the incorrect default
    # Database backend (MariaDB/MySQL):
    StorageType: accounting_storage/mysql
    StorageHost: 127.0.0.1
    StoragePort: 3306
    StorageLoc: slurm_acct_db
    StorageUser: slurmdbd
    StoragePass: "pswd"
  # ...existing code...
  ```

- Inventory updated to include `slurmdbdservers`:

  ```yaml
  # filepath: /Users/andrewma/slurm-ansible-project/inventory/hosts.yml
  # ...existing code...
  all:
    hosts:
      node1:
        ansible_host: 159.89.142.0
    children:
      slurmservers:
        hosts:
          node1:
      slurmexechosts:
        hosts:
          node1:
      slurmdbdservers:
        hosts:
          node1:
  # ...existing code...
  ```

## Testing done

Manual validation on node1:

- Ran a simple srun:
  ```bash
  srun -N1 -n1 echo "hello, world"
  ```
- Submitted an sbatch job and verified accounting entries with sacct:
  ```bash
  cat > ~/hello.slurm <<'EOF'
  #!/bin/bash
  #SBATCH -J hello
  #SBATCH -N 1
  #SBATCH -n 1
  #SBATCH -t 00:02:00
  #SBATCH --output=hello.%j.out
  echo "host: $(hostname)"
  sleep 2
  EOF

  sbatch ~/hello.slurm
  squeue -u "$USER"
  sacct
  ```
- Result: job history recorded in the database (sample `sacct` output to be attached)
```
root@ubuntu-s-1vcpu-1gb-sfo2-01:~# sacct -u root
JobID           JobName  Partition    Account  AllocCPUS      State ExitCode 
------------ ---------- ---------- ---------- ---------- ---------- -------- 
1                  echo      debug       root          1  COMPLETED      0:0 
1.0                echo                  root          1  COMPLETED      0:0 
2              hostname      debug       root          1  COMPLETED      0:0 
3.0            hostname                  root          1  COMPLETED      0:0 
3                 hello      debug       root          1  COMPLETED      0:0 
4.batch           batch                  root          1  COMPLETED      0:0 
```

## Breaking changes

- None in existing workflows, but the cluster now depends on:
  - Running MariaDB on `slurmdbdservers`.
  - Munge configured consistently across controller and slurmdbd.
- Note: Store `StoragePass` in ansible-vault; plaintext used here only for example.

## Related links

- Link to role bug (SlurmctldPidFile appears in slurmdbd.conf): https://github.com/galaxyproject/ansible-slurm/issues/48

- Ansible community.mysql collection: https://docs.ansible.com/ansible/latest/collections/index_module.html#community-mysql
